### PR TITLE
release: v1.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**']
   workflow_call:
 
 jobs:

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -162,17 +162,42 @@ ExpenseTracker/
 ## 4) Git workflow
 
 ### Branch strategy
-- `main` — primary development branch, always buildable
-- Feature branches: `feature/{short-description}` (e.g., `feature/expense-crud`)
-- Bug fixes: `fix/{short-description}` (e.g., `fix/limit-calculation`)
-- Release branches: `release/{version}` (e.g., `release/1.0.0`, `release/1.1.0`)
-- Hotfix branches: `hotfix/{short-description}` (branched from `release/*` or `main`)
+
+- **`main`** — always equals the latest tagged release. No direct pushes. Only updated via release branch merges.
+- **`release/X.Y.x`** — long-lived release branch per minor version (e.g., `release/1.0.x` for all `1.0.*` patches). Created from `main` after a version tag. Accumulates 2–3 changes (fix/\*, chore/\*), then merges to `main` with a new patch tag. Stays open until the next minor version begins (e.g., `release/1.0.x` is retired when `release/1.1.x` is created).
+- **`fix/{short-description}`** — bug fix branches. Created from and merged into the current `release/X.Y.x` branch via PR (e.g., `fix/limit-calculation`).
+- **`chore/{short-description}`** — infrastructure, docs, or tooling changes. Created from and merged into the current `release/X.Y.x` branch via PR.
+- **`feature/{short-description}`** — feature branches for new minor/major versions. Created from `main` and merged into `main` or a new release branch.
+- **`hotfix/{short-description}`** — urgent fixes that cannot wait for the normal release cycle. Created from `main`, merged to both `main` and the active release branch.
 
 ### Workflow
-- Feature and fix branches are created from `main` and merged back into `main` via PR
-- When a version is ready for release, create a `release/{version}` branch from `main`
-- Release branches receive only bug fixes (cherry-picked or hotfixed)
-- Tags: `1.0.0.0`, `1.1.0.0`, `2.0.0.0.0` etc. on release branch merge commits
+
+```
+main (v1.0.0)
+  └── release/1.0.x
+        ├── fix/some-bug       → PR into release/1.0.x
+        ├── fix/another-bug    → PR into release/1.0.x
+        ├── chore/update-docs  → PR into release/1.0.x
+        └── (2-3 changes ready)
+              → PR release/1.0.x → main
+              → tag v1.0.1 + GitHub Release
+              → deploy (automatic)
+```
+
+- `fix/*` and `chore/*` branches are created **from** the active release branch and PRs target that release branch.
+- When 2–3 changes accumulate on the release branch, open a PR from `release/X.Y.x` → `main`. Squash merge, tag the merge commit (e.g., `v1.0.1`), and create a GitHub Release with notes describing the bundled changes.
+- The release branch stays open after merging — future patches continue on it.
+- Deploy is triggered automatically when `main` receives a push (via `deploy.yml`).
+
+### Version bump advisory
+
+If a change on a `fix/*` or `chore/*` branch is significant enough to warrant a **minor** (new feature) or **major** (breaking change) version bump rather than a patch, the developer or agent must flag this before merging. The change should be moved to a `feature/*` branch targeting a new release cycle instead.
+
+### Tags and GitHub Releases
+
+- Tags follow SemVer with `v` prefix: `v1.0.0`, `v1.0.1`, `v1.1.0`, `v2.0.0`.
+- Every tag gets a **GitHub Release** with a description of what's included (2–3 bullet points per bundled change).
+- Tags are created on `main` merge commits only.
 
 ### Commit messages
 - Format: `type: short description`
@@ -185,11 +210,13 @@ ExpenseTracker/
 - Keep commits atomic — one logical change per commit
 
 ### Pull requests
-- PRs should target `main`
+- PRs from `fix/*` and `chore/*` branches target `release/X.Y.x`
+- PRs from `release/X.Y.x` target `main` (for version releases)
+- PRs from `feature/*` branches target `main` or a new release branch
 - PR title follows the same format as commit messages
 - PR description should explain *what* and *why*, not much of the *how*. And should include a design specified behind the PR content (if applies).
 - All tests must pass before merge
-- Squash merge preferred (clean history on `main`)
+- Squash merge preferred (clean history)
 
 ---
 

--- a/backend/app/schemas/limit.py
+++ b/backend/app/schemas/limit.py
@@ -1,8 +1,8 @@
 import uuid
 from datetime import datetime
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class LimitFilterCreate(BaseModel):
@@ -19,6 +19,13 @@ class LimitCreate(BaseModel):
     )
     filters: list[LimitFilterCreate] = Field(default_factory=list)
 
+    @field_validator("warning_pct")
+    @classmethod
+    def normalize_warning_pct(cls, v: Decimal) -> Decimal:
+        """Round to 2 decimal places so UI round-trip
+        (0-100 int ↔ 0-1 decimal) is lossless."""
+        return v.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
 
 class LimitUpdate(BaseModel):
     """PATCH — partial update."""
@@ -28,6 +35,13 @@ class LimitUpdate(BaseModel):
         None, ge=Decimal("0.01"), le=Decimal("999999.99")
     )
     warning_pct: Decimal | None = Field(None, ge=Decimal("0"), le=Decimal("1"))
+
+    @field_validator("warning_pct")
+    @classmethod
+    def normalize_warning_pct(cls, v: Decimal | None) -> Decimal | None:
+        if v is None:
+            return v
+        return v.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
 class LimitFilterResponse(BaseModel):

--- a/backend/tests/unit/test_insight_service.py
+++ b/backend/tests/unit/test_insight_service.py
@@ -217,3 +217,15 @@ def test_average_series_with_filled_cumulative():
     assert avg[1] == (Decimal("100") + Decimal("120") + Decimal("60")) / 3
     # Day 2: (150 + 150) / 2 = 150  (series2 ends at day 1)
     assert avg[2] == Decimal("150")
+
+
+def test_average_series_skips_empty_period():
+    """When one prior period had zero expenses, _to_cumulative returns {}
+    and _average_series averages over only the periods that had data."""
+    series_with_data = _to_cumulative({0: Decimal("100"), 2: Decimal("50")})
+    empty_period = _to_cumulative({})  # month with zero expenses → {}
+
+    avg = _average_series([series_with_data, empty_period])
+
+    # Empty dict contributes nothing — average is just the one series
+    assert avg == series_with_data

--- a/backend/tests/unit/test_limit_service.py
+++ b/backend/tests/unit/test_limit_service.py
@@ -202,3 +202,21 @@ def test_limit_update_accepts_decimal_warning_pct():
     """LimitUpdate should accept 0-1 range."""
     data = LimitUpdate(warning_pct=Decimal("0.75"))
     assert data.warning_pct == Decimal("0.75")
+
+
+def test_warning_pct_normalizes_excess_precision_on_create():
+    """Excess decimal places are rounded to 2 so UI round-trip is lossless.
+    E.g., 0.3333 → 0.33 prevents silent corruption when editing a limit."""
+    data = LimitCreate(
+        name="Precise",
+        timeframe="weekly",
+        threshold_amount=Decimal("100"),
+        warning_pct=Decimal("0.3333"),
+    )
+    assert data.warning_pct == Decimal("0.33")
+
+
+def test_warning_pct_normalizes_excess_precision_on_update():
+    """LimitUpdate should also normalize precision."""
+    data = LimitUpdate(warning_pct=Decimal("0.8567"))
+    assert data.warning_pct == Decimal("0.86")

--- a/frontend/src/components/charts/spending-trend-chart.tsx
+++ b/frontend/src/components/charts/spending-trend-chart.tsx
@@ -28,7 +28,9 @@ export function SpendingTrendChart({
     return {
       day: point.day,
       current: parseFloat(point.cumulative),
-      ...(avgPoint ? { average: parseFloat(avgPoint.cumulative) } : {}),
+      ...(avgPoint
+        ? { average: parseFloat(avgPoint.cumulative) }
+        : { average: null }),
     };
   });
 
@@ -80,7 +82,7 @@ export function SpendingTrendChart({
                       currencyCode,
                     )}
                   </p>
-                  {payload[1] && (
+                  {payload[1] && payload[1].value != null && (
                     <p className="text-sm text-muted-foreground">
                       Average:{' '}
                       {formatCurrency(
@@ -108,6 +110,7 @@ export function SpendingTrendChart({
             strokeDasharray="6 4"
             strokeOpacity={0.4}
             dot={false}
+            connectNulls
           />
         </ComposedChart>
       </ResponsiveContainer>


### PR DESCRIPTION
## v1.0.1 Release

Bundled changes since v1.0.0:

### chore: update branching strategy and CI
- CONVENTIONS.md: replace branch strategy with release-branch model (fix/* → release/X.Y.x → main)
- CI: add release/** to push and pull_request triggers
- Add version bump advisory and GitHub Releases policy

### fix: normalize warning_pct precision
- Pydantic field_validator with ROUND_HALF_UP on LimitCreate and LimitUpdate
- Prevents silent data corruption when editing limits (0.3333 → 0.33)

### fix: continuous average trend line
- Use null + connectNulls for Recharts dashed average line
- Guard tooltip against null values (no misleading \)
- Backend test documenting _average_series empty-period behavior