### PR TITLE
fix: validate tag input against backend rules

### DIFF
--- a/frontend/src/lib/tag-utils.ts
+++ b/frontend/src/lib/tag-utils.ts
@@ -1,0 +1,22 @@
+/**
+ * Tag validation rules mirrored from backend/app/services/tag.py.
+ * Keep these constants in sync with TAG_PATTERN and the schema length cap.
+ */
+
+export const TAG_PATTERN = /^[a-zA-Z0-9_-]+$/;
+export const TAG_MAX_LENGTH = 50;
+
+/**
+ * Validate a normalized tag name (no `#` prefix, lowercase, trimmed).
+ * Returns null if valid, or a human-readable error message.
+ */
+export function validateTagName(name: string): string | null {
+  if (!name) return null;
+  if (name.length > TAG_MAX_LENGTH) {
+    return `Tags can be up to ${TAG_MAX_LENGTH} characters`;
+  }
+  if (!TAG_PATTERN.test(name)) {
+    return 'Tags can only contain letters, numbers, hyphens, and underscores';
+  }
+  return null;
+}

--- a/frontend/src/routes/add-expense.tsx
+++ b/frontend/src/routes/add-expense.tsx
@@ -28,6 +28,8 @@ import {
 } from '@/components/ui/command';
 import { Calendar } from '@/components/ui/calendar';
 import { cn } from '@/lib/utils';
+import { validateTagName } from '@/lib/tag-utils';
+import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { useCurrency } from '@/hooks/useCurrency';
 import { useCreateExpense } from '@/hooks/useExpenses';
@@ -198,15 +200,22 @@ export default function AddExpense() {
       const existingTag = tags?.find((t) => t.name === normalizedName);
       if (existingTag) {
         handleAddTag(existingTag, options);
-      } else {
-        handleAddTag(
-          {
-            id: `new-${normalizedName}`,
-            name: normalizedName,
-          },
-          options,
-        );
+        return;
       }
+
+      const validationError = validateTagName(normalizedName);
+      if (validationError) {
+        toast.error(validationError);
+        return;
+      }
+
+      handleAddTag(
+        {
+          id: `new-${normalizedName}`,
+          name: normalizedName,
+        },
+        options,
+      );
     },
     [tags, handleAddTag],
   );

--- a/frontend/src/routes/expense-detail.tsx
+++ b/frontend/src/routes/expense-detail.tsx
@@ -42,6 +42,8 @@ import {
 import { Calendar } from '@/components/ui/calendar';
 import { cn } from '@/lib/utils';
 import { getCategoryColor } from '@/lib/expense-utils';
+import { validateTagName } from '@/lib/tag-utils';
+import { toast } from 'sonner';
 import { useCurrency } from '@/hooks/useCurrency';
 import {
   useExpense,
@@ -434,12 +436,19 @@ function ExpenseEditMode({
       const existingTag = tags?.find((t) => t.name === normalizedName);
       if (existingTag) {
         handleAddTag(existingTag, options);
-      } else {
-        handleAddTag(
-          { id: `new-${normalizedName}`, name: normalizedName },
-          options,
-        );
+        return;
       }
+
+      const validationError = validateTagName(normalizedName);
+      if (validationError) {
+        toast.error(validationError);
+        return;
+      }
+
+      handleAddTag(
+        { id: `new-${normalizedName}`, name: normalizedName },
+        options,
+      );
     },
     [tags, handleAddTag],
   );


### PR DESCRIPTION
Addresses the two Copilot review comments on the v1.0.6 release PR (#51) about tag input not validating against backend constraints.

### Problem
`commitTagFromInput` accepted any normalized non-empty input as a new tag. Backend (`backend/app/services/tag.py`) enforces:
- Regex: `^[a-zA-Z0-9_-]+$`
- Max length: 50

So `#foo bar` or a 60-char string produces a chip the UI accepts but the backend rejects with 422 on save. The user loses their work.

### Fix
- New shared validator at `frontend/src/lib/tag-utils.ts` exposing `TAG_PATTERN`, `TAG_MAX_LENGTH`, `validateTagName(name)` — mirrors backend rules.
- `commitTagFromInput` in both `add-expense.tsx` and `expense-detail.tsx` validates before creating `new-*` tags. Invalid input shows a sonner toast and the chip isn't added. Existing tags bypass validation (already vetted at creation).

### Scope
- The bug pre-dates PR #19 (the Enter path had the same gap), but #19's extra commit triggers make it more likely to hit.
- Duplication between the two files remains tracked by the 1.1.0 ExpenseForm extraction.

### Verification
- `prettier`, `eslint`, `tsc -b`, `npm run build` — clean