### PR TITLE
chore: scope updates for v1.0.7 / 1.1.0 and release notes style

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -197,7 +197,8 @@ If a change on a `fix/*` or `chore/*` branch is significant enough to warrant a 
 ### Tags and GitHub Releases
 
 - Tags follow SemVer with `v` prefix: `v1.0.0`, `v1.0.1`, `v1.1.0`, `v2.0.0`.
-- Every tag gets a **GitHub Release** with a description of what's included (2–3 bullet points per bundled change).
+- Every tag gets a **GitHub Release** with a description of what's included.
+- **Release notes are user-facing.** Group by user-visible change, not by PR. Use plain language a non-engineer would understand. Don't link PR numbers or mention internal files. See `v1.0.5` and `v1.0.4` as the reference style: each section is named after what the user experiences (e.g., "Period selection now carries across views"), followed by a short paragraph or bullet list of what changed in practice.
 - Tags are created on `main` merge commits only.
 
 ### Commit messages

--- a/SCOPE.md
+++ b/SCOPE.md
@@ -32,6 +32,14 @@ Ship fast, validate the core expense-tracking loop for one couple.
 - Generate single-use invite link (7-day expiry)
 - Partner joins via invite link → Google sign-in → added to space
 - Invite link invalidated after use
+- Authenticated user already in a space sees a clear "you already have a space" message with a path to leave (issue #18, #54)
+
+### Leave space (v1.0.7+)
+- User can leave any space they're a member of via Settings → Danger Zone
+- Type-to-confirm modal (Stripe/GitHub pattern)
+- Cascade behavior: zero-member spaces are automatically deleted in the same transaction
+- Single endpoint covers the recovery flow for users stuck in the wrong space, and the future shared-family case
+- See #54
 
 ### Expense entry (single-line only)
 - Add single-line expense (amount, merchant, category, datetime, spender, payment method, tags, notes)
@@ -170,6 +178,7 @@ Add recurring expenses and shareable analytics.
 - Share button copies URL with current filters
 
 ### Expense entry improvements
+- Drop time-of-day from expense entry: migrate `expenses.purchase_datetime TIMESTAMPTZ` → `purchase_date DATE`. Users only think in dates; time was never used by any feature. One-time alembic migration converts existing rows via space timezone. Breaking API change (acceptable in 1.1.0 minor bump). See issue #53.
 - Merchant auto-fill: selecting a known merchant auto-fills category, payment method, spender, and tags from the last expense with that merchant
 - Backend: store `last_payment_method_id`, `last_spender_id`, `last_tags` on merchant records (migration needed)
 - Frontend: populate all fields on merchant select (user can override any)
@@ -330,6 +339,7 @@ These features are intentionally excluded from the current roadmap. Do not build
 | File uploads / receipts | Never | Notes-only by design |
 | Transfers | TBD | May never be needed |
 | Real-time sync (WebSocket) | TBD | 2-minute refetch is sufficient |
+| Multiple spaces per user | TBD (if demand emerges) | Schema supports it; the constraint is at the app layer. Leave Space (v1.0.7) is the recovery primitive for any user who needs to switch. Multi-space adds significant UI complexity (space selector everywhere, current-space state, route params) and re-creates data-split problems. Not built until concrete user demand exists. |
 
 ---
 


### PR DESCRIPTION
Documentation updates capturing decisions from the v1.0.6 → v1.0.7 planning discussion. No code changes.

### SCOPE.md

- **§1.0.0 Invite system** — add a bullet for the new "already in a space" guard that #18 ships.
- **§1.0.0 Leave space (v1.0.7+)** — new subsection describing the self-removal + cascade-delete behavior (#54).
- **§1.1.0 Expense entry improvements** — add the `purchase_datetime TIMESTAMPTZ` → `purchase_date DATE` migration (#53).
- **Deferred table** — add "Multiple spaces per user" as TBD (if demand emerges), with rationale linking back to Leave Space.

### CONVENTIONS.md

- **§4 Tags and GitHub Releases** — codify the user-facing release-notes style. Points at v1.0.5 / v1.0.4 as the reference (group by user-visible change, plain language, no PR numbers, no internal files).