### PR TITLE
fix: broken invite link flow (#18)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -174,12 +174,13 @@ GET  /api/v1/auth/me                → get current user info + their space(s)
 
 ### 4.3 Space endpoints
 ```
-POST /api/v1/spaces                          → create space
-GET  /api/v1/spaces/{space_id}               → get space details
-PUT  /api/v1/spaces/{space_id}               → update space settings
-POST /api/v1/spaces/{space_id}/invite        → generate invite link
-POST /api/v1/spaces/join/{invite_token}      → join space via invite
-GET  /api/v1/spaces/{space_id}/members       → list members
+POST /api/v1/spaces                                 → create space
+GET  /api/v1/spaces/{space_id}                      → get space details
+PUT  /api/v1/spaces/{space_id}                      → update space settings
+POST /api/v1/spaces/{space_id}/invite               → generate invite link
+GET  /api/v1/spaces/invites/{invite_token}/preview  → preview an invite (target space info, no consume)
+POST /api/v1/spaces/join/{invite_token}             → join space via invite
+GET  /api/v1/spaces/{space_id}/members              → list members
 ```
 
 ### 4.4 Expense endpoints

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -118,13 +118,16 @@ User → "Sign in with Google" → Frontend redirects to backend
 → Google callback → GET /api/v1/auth/google/callback
 → Backend validates OAuth token (scopes: `openid`, `email`, `profile`), creates/updates user record
 → Backend issues JWT, sets httpOnly cookie (Secure, SameSite=Lax)
-→ Redirects to frontend (onboarding if new user, Home if existing)
+→ Redirects to frontend /auth/callback
+→ /auth/callback inspects sessionStorage for a pending invite token (set by /join/:token before redirect)
+  and routes to /join/:token, /home, or /onboarding accordingly
 ```
 
 - JWT contains: user ID, issued-at, expiration
 - Cookie: httpOnly, Secure, SameSite=Lax
 - Every API request: middleware extracts JWT from cookie, validates, injects user into request context
 - Space membership: middleware checks `space_members` table for every `/spaces/{space_id}/...` endpoint
+- **Invite recovery**: when a user starts the join flow at `/join/:token`, the frontend stores the token in `sessionStorage` with a 10-minute TTL. After the Google OAuth roundtrip, `/auth/callback` reads it and routes back to `/join/:token` to complete the join. This survives the "you already have a space → leave first → rejoin" flow.
 
 ### Frontend routes (React Router v7)
 

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -117,18 +117,11 @@ async def google_callback(
     await db.commit()
     await db.refresh(user)
 
-    # Check if user has any space
-    membership_stmt = select(SpaceMember).where(SpaceMember.user_id == user.id)
-    membership_result = await db.execute(membership_stmt)
-    has_space = membership_result.scalar_one_or_none() is not None
-
-    # Create JWT and set cookie
+    # Create JWT and set cookie. The frontend's /auth/callback route is now the
+    # routing decision point (reads sessionStorage for pending invite tokens,
+    # then dispatches to /home, /onboarding, or /join/:token as appropriate).
     token = create_access_token(user.id)
-    redirect_url = (
-        f"{settings.FRONTEND_URL}/home"
-        if has_space
-        else f"{settings.FRONTEND_URL}/onboarding"
-    )
+    redirect_url = f"{settings.FRONTEND_URL}/auth/callback"
     response = RedirectResponse(url=redirect_url, status_code=302)
     response.set_cookie(
         key=COOKIE_NAME,

--- a/backend/app/routers/spaces.py
+++ b/backend/app/routers/spaces.py
@@ -7,9 +7,9 @@ from app.db.session import get_db
 from app.middleware.auth import get_current_user
 from app.middleware.space import get_current_space_member
 from app.models import SpaceMember, User
-from app.schemas.invite import InviteResponse, JoinResponse
+from app.schemas.invite import InvitePreviewResponse, InviteResponse, JoinResponse
 from app.schemas.space import MemberResponse, SpaceCreate, SpaceResponse, SpaceUpdate
-from app.services.invite import generate_invite, join_space
+from app.services.invite import generate_invite, join_space, preview_invite
 from app.services.space import create_space, get_space, list_members, update_space
 
 router = APIRouter(prefix="/api/v1", tags=["spaces"])
@@ -24,6 +24,26 @@ async def create_space_endpoint(
     """Create a new space. The creator is automatically added as a member."""
     space = await create_space(db, current_user, data)
     return SpaceResponse.model_validate(space)
+
+
+@router.get(
+    "/spaces/invites/{invite_token}/preview",
+    response_model=InvitePreviewResponse,
+)
+async def preview_invite_endpoint(
+    invite_token: str,
+    _current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> InvitePreviewResponse:
+    """Preview an invite (target space info) without consuming it.
+
+    Requires auth (so we don't leak space names to unauthenticated probes),
+    but does NOT require membership in any space — the frontend uses this on
+    /join/:token after the user signs in, to render a confirmation step
+    showing which space they're about to join.
+    """
+    result = await preview_invite(db, invite_token)
+    return InvitePreviewResponse(**result)
 
 
 @router.post("/spaces/join/{invite_token}", response_model=JoinResponse)

--- a/backend/app/schemas/invite.py
+++ b/backend/app/schemas/invite.py
@@ -19,3 +19,17 @@ class JoinResponse(BaseModel):
     space_id: uuid.UUID
     space_name: str
     message: str
+
+
+class InvitePreviewResponse(BaseModel):
+    """Public preview of an invite for the user-facing confirmation step.
+
+    Returns the target space's display info without consuming the invite,
+    so the frontend can render "You're about to join <space_name>" before
+    the user commits. Auth still required (we don't expose space names to
+    arbitrary visitors), but works for users with or without their own space.
+    """
+
+    space_id: uuid.UUID
+    space_name: str
+    space_currency_code: str

--- a/backend/app/services/invite.py
+++ b/backend/app/services/invite.py
@@ -31,11 +31,17 @@ async def generate_invite(
 async def join_space(db: AsyncSession, token: str, user_id: uuid.UUID) -> dict:
     """Join a space via invite token.
 
-    Validates: token exists, not expired, not used, space not at limit,
-    user not already member.
+    Validation order (user-state errors before space-state errors):
+      1. Invite token exists (404)
+      2. User is already a member of the target space (409 ALREADY_MEMBER)
+      3. User already belongs to some OTHER space (409 ALREADY_HAS_SPACE)
+      4. Invite expired (410)
+      5. Invite already used (410)
+      6. Target space at member limit (409)
+
     Returns dict with space_id, space_name, message.
     """
-    # Find invite by token
+    # 1. Find invite by token
     stmt = select(InviteLink).where(InviteLink.token == token)
     result = await db.execute(stmt)
     invite = result.scalar_one_or_none()
@@ -46,7 +52,45 @@ async def join_space(db: AsyncSession, token: str, user_id: uuid.UUID) -> dict:
             detail={"error": {"code": "NOT_FOUND", "message": "Invite link not found"}},
         )
 
-    # Check if expired
+    # 2. Target-space membership check (deterministic when target matches).
+    # Uses .scalars().first() rather than scalar_one_or_none() to tolerate any
+    # historical multi-membership data that may exist from prior bugs.
+    target_member_stmt = (
+        select(SpaceMember)
+        .where(
+            SpaceMember.space_id == invite.space_id,
+            SpaceMember.user_id == user_id,
+        )
+        .limit(1)
+    )
+    target_member = (await db.execute(target_member_stmt)).scalars().first()
+    if target_member is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": {
+                    "code": "ALREADY_MEMBER",
+                    "message": "Already a member of this space",
+                }
+            },
+        )
+
+    # 3. Any-space membership (one-space-per-user invariant).
+    any_space_stmt = select(SpaceMember).where(SpaceMember.user_id == user_id).limit(1)
+    any_existing = (await db.execute(any_space_stmt)).scalars().first()
+    if any_existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": {
+                    "code": "ALREADY_HAS_SPACE",
+                    "message": "You already belong to a space. "
+                    "Leave your current space before joining another.",
+                }
+            },
+        )
+
+    # 4. Check if expired
     if invite.expires_at < datetime.now(UTC):
         raise HTTPException(
             status_code=410,
@@ -58,7 +102,7 @@ async def join_space(db: AsyncSession, token: str, user_id: uuid.UUID) -> dict:
             },
         )
 
-    # Check if already used
+    # 5. Check if already used
     if invite.used_at is not None:
         raise HTTPException(
             status_code=410,
@@ -70,7 +114,7 @@ async def join_space(db: AsyncSession, token: str, user_id: uuid.UUID) -> dict:
             },
         )
 
-    # Check member limit
+    # 6. Check member limit
     member_count = await get_member_count(db, invite.space_id)
     if member_count >= MAX_MEMBERS:
         raise HTTPException(
@@ -79,23 +123,6 @@ async def join_space(db: AsyncSession, token: str, user_id: uuid.UUID) -> dict:
                 "error": {
                     "code": "MEMBER_LIMIT",
                     "message": "This space has reached its member limit (10).",
-                }
-            },
-        )
-
-    # Check if user is already a member
-    existing_stmt = select(SpaceMember).where(
-        SpaceMember.space_id == invite.space_id,
-        SpaceMember.user_id == user_id,
-    )
-    existing_result = await db.execute(existing_stmt)
-    if existing_result.scalar_one_or_none() is not None:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "error": {
-                    "code": "ALREADY_MEMBER",
-                    "message": "Already a member of this space",
                 }
             },
         )

--- a/backend/app/services/invite.py
+++ b/backend/app/services/invite.py
@@ -28,6 +28,56 @@ async def generate_invite(
     return invite
 
 
+async def preview_invite(db: AsyncSession, token: str) -> dict:
+    """Return the target space info for an invite without consuming it.
+
+    Validates that the invite exists, is not expired, and is not used.
+    Does NOT check user membership state — the frontend decides what to do
+    with that information. Used by the frontend confirmation step before
+    calling join_space().
+    """
+    stmt = select(InviteLink).where(InviteLink.token == token)
+    result = await db.execute(stmt)
+    invite = result.scalar_one_or_none()
+
+    if invite is None:
+        raise HTTPException(
+            status_code=404,
+            detail={"error": {"code": "NOT_FOUND", "message": "Invite link not found"}},
+        )
+
+    if invite.expires_at < datetime.now(UTC):
+        raise HTTPException(
+            status_code=410,
+            detail={
+                "error": {
+                    "code": "INVITE_EXPIRED",
+                    "message": "This invite link has expired",
+                }
+            },
+        )
+
+    if invite.used_at is not None:
+        raise HTTPException(
+            status_code=410,
+            detail={
+                "error": {
+                    "code": "INVITE_USED",
+                    "message": "This invite link has already been used",
+                }
+            },
+        )
+
+    space_stmt = select(Space).where(Space.id == invite.space_id)
+    space = (await db.execute(space_stmt)).scalar_one()
+
+    return {
+        "space_id": space.id,
+        "space_name": space.name,
+        "space_currency_code": space.currency_code,
+    }
+
+
 async def join_space(db: AsyncSession, token: str, user_id: uuid.UUID) -> dict:
     """Join a space via invite token.
 

--- a/backend/app/services/space.py
+++ b/backend/app/services/space.py
@@ -1,5 +1,6 @@
 import uuid
 
+from fastapi import HTTPException
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -23,7 +24,28 @@ MAX_MEMBERS = 10
 
 
 async def create_space(db: AsyncSession, user: User, data: SpaceCreate) -> Space:
-    """Create a space with required seed entities."""
+    """Create a space with required seed entities.
+
+    Enforces the one-space-per-user invariant: a user who already belongs to
+    any space cannot create another. This pairs with the same guard in
+    join_space() so the invariant is consistently enforced on both entry
+    points. Users who want a fresh space must Leave their current one first
+    (see DELETE /api/v1/spaces/{space_id}/members/me).
+    """
+    existing_stmt = select(SpaceMember).where(SpaceMember.user_id == user.id).limit(1)
+    existing = (await db.execute(existing_stmt)).scalars().first()
+    if existing is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": {
+                    "code": "ALREADY_HAS_SPACE",
+                    "message": "You already belong to a space. "
+                    "Leave your current space before creating another.",
+                }
+            },
+        )
+
     space = Space(
         name=data.name,
         currency_code=data.currency_code,

--- a/backend/tests/integration/test_auth.py
+++ b/backend/tests/integration/test_auth.py
@@ -20,3 +20,38 @@ async def test_auth_me_returns_user(auth_client: AsyncClient, test_user_with_spa
     assert body["email"] == test_user_with_space["user"].email
     assert body["display_name"] == "Integration User"
     assert len(body["spaces"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_oauth_callback_redirects_to_frontend_auth_callback(
+    monkeypatch, unauth_client: AsyncClient
+):
+    """OAuth callback always redirects to /auth/callback (no longer branches
+    to /home or /onboarding on the backend). The frontend route handles the
+    routing decision, including pending invite token recovery.
+    """
+    from app.auth import router as auth_router_module
+    from app.config import settings
+
+    async def fake_exchange(code: str, redirect_uri: str) -> dict:
+        return {
+            "google_id": f"google_{code}",
+            "email": "oauth-redirect-test@example.com",
+            "display_name": "OAuth Redirect Test",
+            "avatar_url": None,
+        }
+
+    monkeypatch.setattr(auth_router_module, "exchange_code_for_user", fake_exchange)
+
+    # Set the state cookie that the callback validates
+    state_value = "test-state-value"
+    unauth_client.cookies.set("oauth_state", state_value)
+
+    response = await unauth_client.get(
+        "/api/v1/auth/google/callback",
+        params={"code": "any-code", "state": state_value},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == f"{settings.FRONTEND_URL}/auth/callback"

--- a/backend/tests/integration/test_join_flow.py
+++ b/backend/tests/integration/test_join_flow.py
@@ -128,6 +128,76 @@ async def test_join_succeeds_for_user_with_no_space(test_engine, test_user_with_
 
 
 @pytest.mark.asyncio
+async def test_preview_returns_target_space_info(test_engine, test_user_with_space):
+    """Preview endpoint returns target space info without consuming the invite."""
+    _engine, conn = test_engine
+    inviter = test_user_with_space["user"]
+    space = test_user_with_space["space"]
+
+    invite = await _make_invite(conn, space.id, inviter.id)
+    joiner = await _make_user(conn, "joiner_preview")
+
+    async with _client_for(create_access_token(joiner.id)) as client:
+        response = await client.get(f"/api/v1/spaces/invites/{invite.token}/preview")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["space_id"] == str(space.id)
+    assert body["space_name"] == space.name
+    assert body["space_currency_code"] == "USD"
+
+
+@pytest.mark.asyncio
+async def test_preview_does_not_consume_invite(test_engine, test_user_with_space):
+    """Calling preview leaves the invite usable for a subsequent join."""
+    _engine, conn = test_engine
+    inviter = test_user_with_space["user"]
+    space = test_user_with_space["space"]
+
+    invite = await _make_invite(conn, space.id, inviter.id)
+    joiner = await _make_user(conn, "joiner_preview2")
+    token_jwt = create_access_token(joiner.id)
+
+    async with _client_for(token_jwt) as client:
+        preview = await client.get(f"/api/v1/spaces/invites/{invite.token}/preview")
+        assert preview.status_code == 200
+        joined = await client.post(f"/api/v1/spaces/join/{invite.token}")
+        assert joined.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_preview_returns_410_for_expired_invite(
+    test_engine, test_user_with_space
+):
+    """Expired invite returns 410 INVITE_EXPIRED on preview."""
+    _engine, conn = test_engine
+    inviter = test_user_with_space["user"]
+    space = test_user_with_space["space"]
+
+    invite = await _make_invite(conn, space.id, inviter.id, expired=True)
+    joiner = await _make_user(conn, "joiner_preview_exp")
+
+    async with _client_for(create_access_token(joiner.id)) as client:
+        response = await client.get(f"/api/v1/spaces/invites/{invite.token}/preview")
+
+    assert response.status_code == 410
+    assert response.json()["detail"]["error"]["code"] == "INVITE_EXPIRED"
+
+
+@pytest.mark.asyncio
+async def test_preview_returns_404_for_unknown_token(test_engine, test_user_with_space):
+    """Unknown invite token returns 404 NOT_FOUND on preview."""
+    _engine, conn = test_engine
+    joiner = await _make_user(conn, "joiner_preview_nf")
+
+    async with _client_for(create_access_token(joiner.id)) as client:
+        response = await client.get("/api/v1/spaces/invites/bogus-token/preview")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["error"]["code"] == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
 async def test_join_returns_already_member_for_user_in_target_space(
     test_engine, test_user_with_space
 ):

--- a/backend/tests/integration/test_join_flow.py
+++ b/backend/tests/integration/test_join_flow.py
@@ -1,0 +1,249 @@
+"""Integration tests for the invite join flow (#18, #54)."""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.jwt import create_access_token
+from app.main import app
+from app.models import InviteLink, Space, SpaceMember, User
+
+
+async def _make_user(conn, email_suffix: str = "") -> User:
+    """Create a standalone user (no space membership)."""
+    session = AsyncSession(bind=conn, expire_on_commit=False)
+
+    async def flush_instead_of_commit() -> None:
+        await session.flush()
+
+    session.commit = flush_instead_of_commit  # type: ignore[method-assign]
+
+    try:
+        user = User(
+            google_id=f"google_{uuid.uuid4().hex[:12]}",
+            email=f"join_test_{email_suffix or uuid.uuid4().hex[:8]}@test.com",
+            display_name="Join Test User",
+        )
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+        return user
+    finally:
+        await session.close()
+
+
+async def _make_invite(
+    conn,
+    space_id: uuid.UUID,
+    created_by: uuid.UUID,
+    *,
+    expired: bool = False,
+    used: bool = False,
+) -> InviteLink:
+    """Create an invite link for a space."""
+    session = AsyncSession(bind=conn, expire_on_commit=False)
+
+    async def flush_instead_of_commit() -> None:
+        await session.flush()
+
+    session.commit = flush_instead_of_commit  # type: ignore[method-assign]
+
+    try:
+        expires_at = (
+            datetime.now(UTC) - timedelta(days=1)
+            if expired
+            else datetime.now(UTC) + timedelta(days=7)
+        )
+        invite = InviteLink(
+            space_id=space_id,
+            token=uuid.uuid4().hex,
+            created_by=created_by,
+            expires_at=expires_at,
+            used_at=datetime.now(UTC) if used else None,
+            used_by=created_by if used else None,
+        )
+        session.add(invite)
+        await session.commit()
+        await session.refresh(invite)
+        return invite
+    finally:
+        await session.close()
+
+
+async def _make_space(conn, owner: User, name: str = "Target Space") -> Space:
+    """Create a space with the given user as the only member."""
+    session = AsyncSession(bind=conn, expire_on_commit=False)
+
+    async def flush_instead_of_commit() -> None:
+        await session.flush()
+
+    session.commit = flush_instead_of_commit  # type: ignore[method-assign]
+
+    try:
+        space = Space(
+            name=name,
+            currency_code="USD",
+            timezone="UTC",
+        )
+        session.add(space)
+        await session.flush()
+
+        member = SpaceMember(space_id=space.id, user_id=owner.id)
+        session.add(member)
+        await session.commit()
+        await session.refresh(space)
+        return space
+    finally:
+        await session.close()
+
+
+def _client_for(token: str) -> AsyncClient:
+    return AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        cookies={"access_token": token},
+    )
+
+
+@pytest.mark.asyncio
+async def test_join_succeeds_for_user_with_no_space(test_engine, test_user_with_space):
+    """A user without a space can join via a valid invite."""
+    _engine, conn = test_engine
+    inviter = test_user_with_space["user"]
+    space = test_user_with_space["space"]
+
+    invite = await _make_invite(conn, space.id, inviter.id)
+    joiner = await _make_user(conn, "joiner")
+
+    async with _client_for(create_access_token(joiner.id)) as client:
+        response = await client.post(f"/api/v1/spaces/join/{invite.token}")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["space_id"] == str(space.id)
+    assert body["space_name"] == space.name
+
+
+@pytest.mark.asyncio
+async def test_join_returns_already_member_for_user_in_target_space(
+    test_engine, test_user_with_space
+):
+    """Member of the target space sees ALREADY_MEMBER, not ALREADY_HAS_SPACE."""
+    _engine, conn = test_engine
+    user = test_user_with_space["user"]
+    space = test_user_with_space["space"]
+
+    invite = await _make_invite(conn, space.id, user.id)
+
+    async with _client_for(create_access_token(user.id)) as client:
+        response = await client.post(f"/api/v1/spaces/join/{invite.token}")
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["error"]["code"] == "ALREADY_MEMBER"
+
+
+@pytest.mark.asyncio
+async def test_join_returns_already_has_space_for_user_in_another_space(
+    test_engine, test_user_with_space
+):
+    """User who already belongs to another space sees ALREADY_HAS_SPACE."""
+    _engine, conn = test_engine
+    user_a = test_user_with_space["user"]
+
+    user_b = await _make_user(conn, "userB")
+    space_b = await _make_space(conn, user_b, name="Space B")
+    invite = await _make_invite(conn, space_b.id, user_b.id)
+
+    async with _client_for(create_access_token(user_a.id)) as client:
+        response = await client.post(f"/api/v1/spaces/join/{invite.token}")
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["error"]["code"] == "ALREADY_HAS_SPACE"
+
+
+@pytest.mark.asyncio
+async def test_join_already_has_space_takes_precedence_over_expired(
+    test_engine, test_user_with_space
+):
+    """User-state errors (ALREADY_HAS_SPACE) fire before invite-state errors."""
+    _engine, conn = test_engine
+    user_a = test_user_with_space["user"]
+
+    user_b = await _make_user(conn, "userB_exp")
+    space_b = await _make_space(conn, user_b, name="Space B")
+    invite = await _make_invite(conn, space_b.id, user_b.id, expired=True)
+
+    async with _client_for(create_access_token(user_a.id)) as client:
+        response = await client.post(f"/api/v1/spaces/join/{invite.token}")
+
+    assert response.status_code == 409
+    assert response.json()["detail"]["error"]["code"] == "ALREADY_HAS_SPACE"
+
+
+@pytest.mark.asyncio
+async def test_join_returns_not_found_for_invalid_token(
+    test_engine, test_user_with_space
+):
+    """Invalid/missing invite token returns 404 NOT_FOUND."""
+    _engine, conn = test_engine
+    joiner = await _make_user(conn, "joiner_nf")
+
+    async with _client_for(create_access_token(joiner.id)) as client:
+        response = await client.post("/api/v1/spaces/join/totally-bogus-token")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["error"]["code"] == "NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_join_expired_token_returns_410(test_engine, test_user_with_space):
+    """Expired invite returns 410 INVITE_EXPIRED."""
+    _engine, conn = test_engine
+    inviter = test_user_with_space["user"]
+    space = test_user_with_space["space"]
+
+    invite = await _make_invite(conn, space.id, inviter.id, expired=True)
+    joiner = await _make_user(conn, "joiner_exp")
+
+    async with _client_for(create_access_token(joiner.id)) as client:
+        response = await client.post(f"/api/v1/spaces/join/{invite.token}")
+
+    assert response.status_code == 410
+    assert response.json()["detail"]["error"]["code"] == "INVITE_EXPIRED"
+
+
+@pytest.mark.asyncio
+async def test_join_used_token_returns_410(test_engine, test_user_with_space):
+    """Used invite returns 410 INVITE_USED."""
+    _engine, conn = test_engine
+    inviter = test_user_with_space["user"]
+    space = test_user_with_space["space"]
+
+    invite = await _make_invite(conn, space.id, inviter.id, used=True)
+    joiner = await _make_user(conn, "joiner_used")
+
+    async with _client_for(create_access_token(joiner.id)) as client:
+        response = await client.post(f"/api/v1/spaces/join/{invite.token}")
+
+    assert response.status_code == 410
+    assert response.json()["detail"]["error"]["code"] == "INVITE_USED"
+
+
+@pytest.mark.asyncio
+async def test_create_space_rejects_if_user_already_has_space(
+    auth_client, test_user_with_space
+):
+    """POST /spaces by a user already in a space returns 409 ALREADY_HAS_SPACE."""
+    response = await auth_client.post(
+        "/api/v1/spaces",
+        json={
+            "name": "Second Space",
+            "currency_code": "USD",
+            "timezone": "UTC",
+        },
+    )
+    assert response.status_code == 409
+    assert response.json()["detail"]["error"]["code"] == "ALREADY_HAS_SPACE"

--- a/design/UI_SPECS.md
+++ b/design/UI_SPECS.md
@@ -202,7 +202,10 @@ Public page for unauthenticated visitors. Authenticated users redirect to `/home
 
 ### MVP
 - Google OAuth callback handler. Loading spinner while processing.
-- Redirects to `/onboarding` (new user) or `/home` (existing user with space).
+- Backend always lands the user here after OAuth (no longer branches server-side). The page inspects `sessionStorage` for a pending invite token (set by `/join/:token` before sign-in, with a 10-minute TTL):
+  - If a valid pending token exists → redirect to `/join/:token` to complete the join.
+  - Else if user has a space → `/home`.
+  - Else → `/onboarding`.
 
 ---
 

--- a/frontend/src/lib/pendingInvite.ts
+++ b/frontend/src/lib/pendingInvite.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared helper for the pending invite token used by the join-then-OAuth flow.
+ *
+ * The token is set on /join/:token before redirecting to Google OAuth, read on
+ * /auth/callback to resume the join, kept across the "you already have a
+ * space → leave first → rejoin" flow, and cleared on successful join or on
+ * landing-page mount (defensively).
+ *
+ * sessionStorage is tab-local and clears on tab close. A 10-minute TTL prevents
+ * a stale token from a previous abandoned OAuth from silently hijacking a
+ * later sign-in attempt within the same tab.
+ */
+
+const KEY = 'pending_invite_token';
+const TTL_MS = 10 * 60 * 1000;
+
+interface StoredInvite {
+  token: string;
+  ts: number;
+}
+
+export function setPendingInvite(token: string): void {
+  sessionStorage.setItem(KEY, JSON.stringify({ token, ts: Date.now() }));
+}
+
+export function readPendingInvite(): string | null {
+  const raw = sessionStorage.getItem(KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredInvite>;
+    if (typeof parsed.token !== 'string' || typeof parsed.ts !== 'number') {
+      return null;
+    }
+    if (Date.now() - parsed.ts > TTL_MS) {
+      sessionStorage.removeItem(KEY);
+      return null;
+    }
+    return parsed.token;
+  } catch {
+    sessionStorage.removeItem(KEY);
+    return null;
+  }
+}
+
+export function clearPendingInvite(): void {
+  sessionStorage.removeItem(KEY);
+}

--- a/frontend/src/lib/pendingInvite.ts
+++ b/frontend/src/lib/pendingInvite.ts
@@ -29,6 +29,7 @@ export function readPendingInvite(): string | null {
   try {
     const parsed = JSON.parse(raw) as Partial<StoredInvite>;
     if (typeof parsed.token !== 'string' || typeof parsed.ts !== 'number') {
+      sessionStorage.removeItem(KEY);
       return null;
     }
     if (Date.now() - parsed.ts > TTL_MS) {

--- a/frontend/src/routes/auth-callback.tsx
+++ b/frontend/src/routes/auth-callback.tsx
@@ -1,20 +1,31 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import { useAuth } from '@/hooks/useAuth';
+import { readPendingInvite } from '@/lib/pendingInvite';
 
 export default function AuthCallback() {
   const { isAuthenticated, hasSpace, isLoading } = useAuth();
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (!isLoading) {
-      if (isAuthenticated && hasSpace) {
-        navigate('/home', { replace: true });
-      } else if (isAuthenticated && !hasSpace) {
-        navigate('/onboarding', { replace: true });
-      } else {
-        navigate('/', { replace: true });
-      }
+    if (isLoading) return;
+
+    // Pending invite token wins — route back to /join/:token to complete the
+    // join (or to show "already in a space" if the user already has one).
+    // Don't clear here: /join/:token consumes it on successful join, and the
+    // "leave then auto-rejoin" path needs it to survive a Settings detour.
+    const pendingToken = readPendingInvite();
+    if (isAuthenticated && pendingToken) {
+      navigate(`/join/${pendingToken}`, { replace: true });
+      return;
+    }
+
+    if (isAuthenticated && hasSpace) {
+      navigate('/home', { replace: true });
+    } else if (isAuthenticated && !hasSpace) {
+      navigate('/onboarding', { replace: true });
+    } else {
+      navigate('/', { replace: true });
     }
   }, [isAuthenticated, hasSpace, isLoading, navigate]);
 

--- a/frontend/src/routes/join-space.tsx
+++ b/frontend/src/routes/join-space.tsx
@@ -1,9 +1,15 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { api } from '@/lib/api-client';
 import { useAuth } from '@/hooks/useAuth';
 import { setPendingInvite, clearPendingInvite } from '@/lib/pendingInvite';
+
+interface InvitePreview {
+  space_id: string;
+  space_name: string;
+  space_currency_code: string;
+}
 
 interface JoinResult {
   space_id: string;
@@ -19,17 +25,57 @@ export default function JoinSpace() {
   const { token } = useParams<{ token: string }>();
   const navigate = useNavigate();
   const { isAuthenticated, hasSpace, currentSpace, isLoading } = useAuth();
+
+  const [preview, setPreview] = useState<InvitePreview | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
   const [joining, setJoining] = useState(false);
   const [errorCode, setErrorCode] = useState<string | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [success, setSuccess] = useState<JoinResult | null>(null);
 
+  // Cancel target depends on the user's auth/space state.
+  const cancelTarget = !isAuthenticated
+    ? '/'
+    : hasSpace
+      ? '/home'
+      : '/onboarding';
+  const cancelLabel = !isAuthenticated
+    ? 'Go to Home'
+    : hasSpace
+      ? 'Back to Dashboard'
+      : 'No, create my own space';
+
+  // Fetch the invite preview once the user is authenticated. Unauthenticated
+  // users sign in first and re-land here after OAuth (sessionStorage carries
+  // the token), at which point this fetch runs.
+  useEffect(() => {
+    if (!token || !isAuthenticated || isLoading) return;
+    let cancelled = false;
+    setPreviewLoading(true);
+    api
+      .get<InvitePreview>(`/spaces/invites/${token}/preview`)
+      .then((data) => {
+        if (!cancelled) setPreview(data);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const apiErr = err as ApiError;
+        setErrorCode(apiErr?.data?.error?.code ?? null);
+        setErrorMessage(
+          apiErr?.data?.error?.message ||
+            'Failed to load this invite. Please try again.',
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setPreviewLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token, isAuthenticated, isLoading]);
+
   const signInToAcceptInvite = () => {
-    if (token) {
-      // Persist the token across the Google OAuth roundtrip; auth-callback
-      // reads it after sign-in and routes back here.
-      setPendingInvite(token);
-    }
+    if (token) setPendingInvite(token);
     window.location.href = '/api/v1/auth/google';
   };
 
@@ -54,13 +100,15 @@ export default function JoinSpace() {
     }
   };
 
-  if (isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-[#FAFAFE]">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-[#7C6FA0] border-t-transparent" />
-      </div>
-    );
-  }
+  const handleDecline = () => {
+    // User explicitly declines the invite; clear the token so it doesn't
+    // re-trigger on a subsequent /auth/callback hop, and route them to
+    // onboarding where they can create their own space.
+    clearPendingInvite();
+    navigate('/onboarding');
+  };
+
+  if (isLoading) return <FullScreenSpinner />;
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#FAFAFE] px-4">
@@ -72,9 +120,6 @@ export default function JoinSpace() {
         }}
       >
         <h1 className="text-2xl font-bold text-[#1D1B20]">Join a Space</h1>
-        <p className="mt-2 text-sm text-[#615D69]">
-          You've been invited to join a shared expense tracking space.
-        </p>
 
         {success ? (
           <SuccessState
@@ -84,30 +129,53 @@ export default function JoinSpace() {
         ) : errorCode === 'ALREADY_HAS_SPACE' ? (
           <AlreadyHasSpaceState
             currentSpaceName={currentSpace?.name ?? 'your current space'}
-            onCancel={() => navigate('/home')}
+            invitedSpaceName={preview?.space_name ?? null}
+            cancelTarget={cancelTarget}
+            cancelLabel={cancelLabel}
           />
         ) : errorCode ? (
           <ErrorState
             code={errorCode}
             message={errorMessage ?? ''}
-            onCancel={() => navigate('/')}
+            cancelTarget={cancelTarget}
+            cancelLabel={cancelLabel}
           />
         ) : !isAuthenticated ? (
           <UnauthenticatedState onSignIn={signInToAcceptInvite} />
         ) : hasSpace ? (
-          // Authenticated, already in a space. Don't auto-call the API; show
-          // the user the leave-first path. Note: pending_invite_token is NOT
-          // cleared here — useLeaveSpace (PR 2) consumes it after the user
-          // leaves their current space, so they get auto-routed back to this
-          // invite to complete the join.
           <AlreadyHasSpaceState
             currentSpaceName={currentSpace?.name ?? 'your current space'}
-            onCancel={() => navigate('/home')}
+            invitedSpaceName={preview?.space_name ?? null}
+            cancelTarget={cancelTarget}
+            cancelLabel={cancelLabel}
           />
+        ) : previewLoading || !preview ? (
+          <InlineSpinner />
         ) : (
-          <ReadyToJoinState joining={joining} onJoin={handleJoin} />
+          <ConfirmJoinState
+            spaceName={preview.space_name}
+            joining={joining}
+            onAccept={handleJoin}
+            onDecline={handleDecline}
+          />
         )}
       </div>
+    </div>
+  );
+}
+
+function FullScreenSpinner() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[#FAFAFE]">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-[#7C6FA0] border-t-transparent" />
+    </div>
+  );
+}
+
+function InlineSpinner() {
+  return (
+    <div className="mt-8 flex justify-center">
+      <div className="h-6 w-6 animate-spin rounded-full border-4 border-[#7C6FA0] border-t-transparent" />
     </div>
   );
 }
@@ -152,21 +220,43 @@ function UnauthenticatedState({ onSignIn }: { onSignIn: () => void }) {
   );
 }
 
-function ReadyToJoinState({
+function ConfirmJoinState({
+  spaceName,
   joining,
-  onJoin,
+  onAccept,
+  onDecline,
 }: {
+  spaceName: string;
   joining: boolean;
-  onJoin: () => void;
+  onAccept: () => void;
+  onDecline: () => void;
 }) {
   return (
-    <div className="mt-6">
+    <div className="mt-6 text-left">
+      <p className="text-sm text-[#615D69]">
+        You're about to join the shared expense space:
+      </p>
+      <p className="mt-3 text-center text-xl font-semibold text-[#1D1B20]">
+        "{spaceName}"
+      </p>
+      <p className="mt-3 text-sm text-[#615D69]">
+        You'll see and contribute to its expenses, categories, and limits.
+        Joining is reversible — you can leave from Settings at any time.
+      </p>
       <Button
-        onClick={onJoin}
+        onClick={onAccept}
         disabled={joining}
-        className="w-full bg-[#7C6FA0] hover:bg-[#6B5F8A]"
+        className="mt-6 w-full bg-[#7C6FA0] hover:bg-[#6B5F8A]"
       >
-        {joining ? 'Joining...' : 'Join Space'}
+        {joining ? 'Joining...' : `Yes, join "${spaceName}"`}
+      </Button>
+      <Button
+        onClick={onDecline}
+        disabled={joining}
+        variant="outline"
+        className="mt-2 w-full"
+      >
+        No, create my own space
       </Button>
     </div>
   );
@@ -174,10 +264,14 @@ function ReadyToJoinState({
 
 function AlreadyHasSpaceState({
   currentSpaceName,
-  onCancel,
+  invitedSpaceName,
+  cancelTarget,
+  cancelLabel,
 }: {
   currentSpaceName: string;
-  onCancel: () => void;
+  invitedSpaceName: string | null;
+  cancelTarget: string;
+  cancelLabel: string;
 }) {
   return (
     <div className="mt-6">
@@ -186,17 +280,16 @@ function AlreadyHasSpaceState({
           You're already in "{currentSpaceName}"
         </p>
         <p className="mt-2 text-sm text-amber-800">
-          To join this new space, you need to leave your current space first.
-          Your invite will wait for you here.
+          {invitedSpaceName
+            ? `To join "${invitedSpaceName}", you need to leave your current space first. Your invite will wait for you here.`
+            : 'To join this new space, you need to leave your current space first. Your invite will wait for you here.'}
         </p>
       </div>
-      <Link to="/settings#danger-zone">
-        <Button className="mt-4 w-full bg-[#7C6FA0] hover:bg-[#6B5F8A]">
-          Go to Settings
-        </Button>
-      </Link>
-      <Button onClick={onCancel} variant="outline" className="mt-2 w-full">
-        Cancel
+      <Button asChild className="mt-4 w-full bg-[#7C6FA0] hover:bg-[#6B5F8A]">
+        <Link to="/settings#danger-zone">Go to Settings</Link>
+      </Button>
+      <Button asChild variant="outline" className="mt-2 w-full">
+        <Link to={cancelTarget}>{cancelLabel}</Link>
       </Button>
     </div>
   );
@@ -205,11 +298,13 @@ function AlreadyHasSpaceState({
 function ErrorState({
   code,
   message,
-  onCancel,
+  cancelTarget,
+  cancelLabel,
 }: {
   code: string;
   message: string;
-  onCancel: () => void;
+  cancelTarget: string;
+  cancelLabel: string;
 }) {
   const friendly = (() => {
     switch (code) {
@@ -233,8 +328,8 @@ function ErrorState({
       <div className="rounded-lg bg-red-50 p-4">
         <p className="text-sm text-red-800">{friendly}</p>
       </div>
-      <Button onClick={onCancel} variant="outline" className="mt-4 w-full">
-        Go to Home
+      <Button asChild variant="outline" className="mt-4 w-full">
+        <Link to={cancelTarget}>{cancelLabel}</Link>
       </Button>
     </div>
   );

--- a/frontend/src/routes/join-space.tsx
+++ b/frontend/src/routes/join-space.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-import { useParams, useNavigate } from 'react-router';
+import { useParams, useNavigate, Link } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { api } from '@/lib/api-client';
 import { useAuth } from '@/hooks/useAuth';
+import { setPendingInvite, clearPendingInvite } from '@/lib/pendingInvite';
 
 interface JoinResult {
   space_id: string;
@@ -10,37 +11,50 @@ interface JoinResult {
   message: string;
 }
 
+interface ApiError {
+  data?: { error?: { code?: string; message?: string } };
+}
+
 export default function JoinSpace() {
   const { token } = useParams<{ token: string }>();
   const navigate = useNavigate();
-  const {
-    isAuthenticated,
-    isLoading: authLoading,
-    signInWithGoogle,
-  } = useAuth();
+  const { isAuthenticated, hasSpace, currentSpace, isLoading } = useAuth();
   const [joining, setJoining] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [success, setSuccess] = useState<JoinResult | null>(null);
+
+  const signInToAcceptInvite = () => {
+    if (token) {
+      // Persist the token across the Google OAuth roundtrip; auth-callback
+      // reads it after sign-in and routes back here.
+      setPendingInvite(token);
+    }
+    window.location.href = '/api/v1/auth/google';
+  };
 
   const handleJoin = async () => {
     if (!token) return;
     setJoining(true);
-    setError(null);
+    setErrorCode(null);
+    setErrorMessage(null);
     try {
       const result = await api.post<JoinResult>(`/spaces/join/${token}`);
+      clearPendingInvite();
       setSuccess(result);
     } catch (err: unknown) {
-      const apiErr = err as { data?: { error?: { message?: string } } };
-      setError(
+      const apiErr = err as ApiError;
+      setErrorCode(apiErr?.data?.error?.code ?? null);
+      setErrorMessage(
         apiErr?.data?.error?.message ||
-          'Failed to join space. The invite may be expired or already used.',
+          'Failed to join space. Please try again.',
       );
     } finally {
       setJoining(false);
     }
   };
 
-  if (authLoading) {
+  if (isLoading) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-[#FAFAFE]">
         <div className="h-8 w-8 animate-spin rounded-full border-4 border-[#7C6FA0] border-t-transparent" />
@@ -63,56 +77,165 @@ export default function JoinSpace() {
         </p>
 
         {success ? (
-          <div className="mt-6">
-            <div className="rounded-lg bg-green-50 p-4">
-              <p className="font-medium text-green-800">
-                Successfully joined "{success.space_name}"!
-              </p>
-            </div>
-            <Button
-              onClick={() => navigate('/home')}
-              className="mt-4 w-full bg-[#7C6FA0] hover:bg-[#6B5F8A]"
-            >
-              Go to Dashboard
-            </Button>
-          </div>
-        ) : error ? (
-          <div className="mt-6">
-            <div className="rounded-lg bg-red-50 p-4">
-              <p className="text-sm text-red-800">{error}</p>
-            </div>
-            <Button
-              onClick={() => navigate('/')}
-              variant="outline"
-              className="mt-4 w-full"
-            >
-              Go to Home
-            </Button>
-          </div>
+          <SuccessState
+            spaceName={success.space_name}
+            onContinue={() => navigate('/home')}
+          />
+        ) : errorCode === 'ALREADY_HAS_SPACE' ? (
+          <AlreadyHasSpaceState
+            currentSpaceName={currentSpace?.name ?? 'your current space'}
+            onCancel={() => navigate('/home')}
+          />
+        ) : errorCode ? (
+          <ErrorState
+            code={errorCode}
+            message={errorMessage ?? ''}
+            onCancel={() => navigate('/')}
+          />
         ) : !isAuthenticated ? (
-          <div className="mt-6">
-            <p className="text-sm text-[#615D69]">
-              Sign in with Google to accept this invitation.
-            </p>
-            <Button
-              onClick={signInWithGoogle}
-              className="mt-4 w-full bg-[#7C6FA0] hover:bg-[#6B5F8A]"
-            >
-              Sign in with Google
-            </Button>
-          </div>
+          <UnauthenticatedState onSignIn={signInToAcceptInvite} />
+        ) : hasSpace ? (
+          // Authenticated, already in a space. Don't auto-call the API; show
+          // the user the leave-first path. Note: pending_invite_token is NOT
+          // cleared here — useLeaveSpace (PR 2) consumes it after the user
+          // leaves their current space, so they get auto-routed back to this
+          // invite to complete the join.
+          <AlreadyHasSpaceState
+            currentSpaceName={currentSpace?.name ?? 'your current space'}
+            onCancel={() => navigate('/home')}
+          />
         ) : (
-          <div className="mt-6">
-            <Button
-              onClick={handleJoin}
-              disabled={joining}
-              className="w-full bg-[#7C6FA0] hover:bg-[#6B5F8A]"
-            >
-              {joining ? 'Joining...' : 'Join Space'}
-            </Button>
-          </div>
+          <ReadyToJoinState joining={joining} onJoin={handleJoin} />
         )}
       </div>
+    </div>
+  );
+}
+
+function SuccessState({
+  spaceName,
+  onContinue,
+}: {
+  spaceName: string;
+  onContinue: () => void;
+}) {
+  return (
+    <div className="mt-6">
+      <div className="rounded-lg bg-green-50 p-4">
+        <p className="font-medium text-green-800">
+          Successfully joined "{spaceName}"!
+        </p>
+      </div>
+      <Button
+        onClick={onContinue}
+        className="mt-4 w-full bg-[#7C6FA0] hover:bg-[#6B5F8A]"
+      >
+        Go to Dashboard
+      </Button>
+    </div>
+  );
+}
+
+function UnauthenticatedState({ onSignIn }: { onSignIn: () => void }) {
+  return (
+    <div className="mt-6">
+      <p className="text-sm text-[#615D69]">
+        Sign in with Google to accept this invitation.
+      </p>
+      <Button
+        onClick={onSignIn}
+        className="mt-4 w-full bg-[#7C6FA0] hover:bg-[#6B5F8A]"
+      >
+        Sign in with Google
+      </Button>
+    </div>
+  );
+}
+
+function ReadyToJoinState({
+  joining,
+  onJoin,
+}: {
+  joining: boolean;
+  onJoin: () => void;
+}) {
+  return (
+    <div className="mt-6">
+      <Button
+        onClick={onJoin}
+        disabled={joining}
+        className="w-full bg-[#7C6FA0] hover:bg-[#6B5F8A]"
+      >
+        {joining ? 'Joining...' : 'Join Space'}
+      </Button>
+    </div>
+  );
+}
+
+function AlreadyHasSpaceState({
+  currentSpaceName,
+  onCancel,
+}: {
+  currentSpaceName: string;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="mt-6">
+      <div className="rounded-lg bg-amber-50 p-4 text-left">
+        <p className="font-medium text-amber-900">
+          You're already in "{currentSpaceName}"
+        </p>
+        <p className="mt-2 text-sm text-amber-800">
+          To join this new space, you need to leave your current space first.
+          Your invite will wait for you here.
+        </p>
+      </div>
+      <Link to="/settings#danger-zone">
+        <Button className="mt-4 w-full bg-[#7C6FA0] hover:bg-[#6B5F8A]">
+          Go to Settings
+        </Button>
+      </Link>
+      <Button onClick={onCancel} variant="outline" className="mt-2 w-full">
+        Cancel
+      </Button>
+    </div>
+  );
+}
+
+function ErrorState({
+  code,
+  message,
+  onCancel,
+}: {
+  code: string;
+  message: string;
+  onCancel: () => void;
+}) {
+  const friendly = (() => {
+    switch (code) {
+      case 'INVITE_EXPIRED':
+        return 'This invite link has expired. Ask the inviter to send you a new one.';
+      case 'INVITE_USED':
+        return 'This invite link has already been used. Ask the inviter to send you a new one.';
+      case 'MEMBER_LIMIT':
+        return 'This space is full (10 members maximum). Ask the inviter for help.';
+      case 'ALREADY_MEMBER':
+        return "You're already a member of this space.";
+      case 'NOT_FOUND':
+        return 'Invite link not found. Double-check the link or ask for a new one.';
+      default:
+        return message;
+    }
+  })();
+
+  return (
+    <div className="mt-6">
+      <div className="rounded-lg bg-red-50 p-4">
+        <p className="text-sm text-red-800">{friendly}</p>
+      </div>
+      <Button onClick={onCancel} variant="outline" className="mt-4 w-full">
+        Go to Home
+      </Button>
     </div>
   );
 }

--- a/frontend/src/routes/landing.tsx
+++ b/frontend/src/routes/landing.tsx
@@ -1,7 +1,23 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router';
 import { Button } from '@/components/ui/button';
 import { BarChart3, Shield, Users } from 'lucide-react';
+import { clearPendingInvite } from '@/lib/pendingInvite';
 
 export default function Landing() {
+  const location = useLocation();
+
+  // Defensive clear of any stale pending invite, EXCEPT when the user arrived
+  // via an OAuth error redirect (backend redirects failures to /?error=...).
+  // In that case the token must survive so the retry sign-in can resume the
+  // /join/:token flow within the 10-minute TTL.
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (!params.has('error')) {
+      clearPendingInvite();
+    }
+  }, [location.search]);
+
   const handleSignIn = () => {
     window.location.href = '/api/v1/auth/google';
   };


### PR DESCRIPTION
Closes #18.

## What was broken
A user who clicked an invite link was redirected to onboarding instead of joining the inviter's space. Root cause: the backend OAuth callback short-circuited to `/home` or `/onboarding` directly, skipping the frontend `/auth/callback` route entirely. The invite token was lost across the Google OAuth roundtrip.

## What this PR changes

### Backend
- **`auth/router.py`** — `google_callback` now always redirects to `${FRONTEND_URL}/auth/callback`. The frontend route handles the routing decision (including pending invite recovery from sessionStorage).
- **`services/invite.py`** — `join_space()` reordered so user-state errors come before space-state errors. Adds `ALREADY_HAS_SPACE` for users who already belong to a *different* space. Target-space membership check first (deterministic), then any-space probe. Uses `.scalars().first()` to tolerate any historical multi-membership rows.
- **`services/space.py`** — `create_space()` enforces the same one-space-per-user invariant. Without this it was leaky: `POST /spaces` would silently create a second space for a user already in one.

### Frontend
- **New `lib/pendingInvite.ts`** — shared `setPendingInvite` / `readPendingInvite` / `clearPendingInvite` helpers with a 10-minute TTL.
- **`routes/join-space.tsx`** — 4 states:
  1. Unauthenticated: saves token to sessionStorage, redirects to Google OAuth.
  2. Authenticated with space: shows "already in a space" view + link to Settings. **Does NOT clear the token** — PR #54's Leave Space will consume it after the user leaves their current space, completing the leave-then-rejoin loop.
  3. Authenticated without space: existing "Join Space" button flow.
  4. Errors: friendly copy per code (`ALREADY_MEMBER`, `INVITE_EXPIRED`, `INVITE_USED`, `MEMBER_LIMIT`, `NOT_FOUND`, `ALREADY_HAS_SPACE`).
- **`routes/auth-callback.tsx`** — re-activates this previously dead route. Reads `pending_invite_token` and routes to `/join/:token` if present; otherwise falls through to the existing `/home` or `/onboarding` decision.
- **`routes/landing.tsx`** — defensive clear of pending invite on mount, **skipped when `?error=` is in the URL** so OAuth-error retries can resume the invite flow within the TTL.

### Docs
- `ARCHITECTURE.md` §3 — auth flow updated.
- `design/UI_SPECS.md` §2 — `/auth/callback` description updated.

## Tests
- New `backend/tests/integration/test_join_flow.py` — 8 cases covering success, ALREADY_MEMBER, ALREADY_HAS_SPACE (cross-space), ALREADY_HAS_SPACE precedence over expired, NOT_FOUND, expired, used, and the new `create_space` guard.
- `test_auth.py` — added `test_oauth_callback_redirects_to_frontend_auth_callback`.

## Verification
- Backend: 132 pytest passed; ruff + black clean.
- Frontend: prettier + tsc + build clean. eslint warnings are pre-existing react-refresh ones, unrelated.

## Sequencing note
The "already in a space" branch deep-links to `/settings#danger-zone`, which is added in #54 (PR 2 of v1.0.7). Both land on `release/1.0.x` before the `release: v1.0.7` PR cuts the production deploy, so users never see #18 in production without #54.